### PR TITLE
Fix missing raise in compressed proof handling

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -585,9 +585,9 @@ class MM:
                 # label bloc
                 self.treat_step(self.labels[plabels[proof_int] or ''], stack)
             elif proof_int >= label_end + n_saved_stmts:
-                MMError(
+                raise MMError(
                     ("Not enough saved proof steps ({} saved but calling " +
-                    "the {}th).").format(
+                     "the {}th).").format(
                         n_saved_stmts,
                         proof_int))
             else:  # label_end <= proof_int < label_end + n_saved_stmts


### PR DESCRIPTION
## Summary
- ensure compressed proof errors raise an exception

## Testing
- `python3 -m py_compile mmverify.py`
- `python3 mmverify.py --help | head`