### PR TITLE
Fix label validation

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -451,6 +451,8 @@ class MM:
             elif tok[0] != '$':
                 if tok in self.labels:
                     raise MMError("Label {} multiply defined.".format(tok))
+                if not all(ch.isalnum() or ch in '-_.' for ch in tok):
+                    raise MMError(("Only letters, digits, '_', '-', and '.' are allowed in labels: {}").format(tok))
                 label = tok
                 vprint(20, 'Label:', label)
                 if label == self.stop_label:


### PR DESCRIPTION
## Summary
- ensure labels only use allowed characters

## Testing
- `python3 mmverify.py demo.mm -v1`
- `python3 mmverify.py demo-bad.mm -v1` *(fails: Only letters, digits, '_', '-', and '.' are allowed in labels: t^)*


------
https://chatgpt.com/codex/tasks/task_e_6842eab8b70c8328b825521d4fd3936c