### PR TITLE
Fix label validation

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -310,6 +310,8 @@ class MM:
 
     def add_c(self, tok: Const) -> None:
         """Add a constant to the database."""
+        if '$' in tok:
+            raise MMError("Character '$' not allowed in math symbol: {}".format(tok))
         if tok in self.constants:
             raise MMError(
                 'Constant already declared: {}'.format(tok))
@@ -322,6 +324,8 @@ class MM:
         """Add a variable to the frame stack top (that is, the current frame)
         of the database.  Allow local variable declarations.
         """
+        if '$' in tok:
+            raise MMError("Character '$' not allowed in math symbol: {}".format(tok))
         if self.fs.lookup_v(tok):
             raise MMError('var already declared and active: {}'.format(tok))
         if tok in self.constants:
@@ -451,6 +455,8 @@ class MM:
             elif tok[0] != '$':
                 if tok in self.labels:
                     raise MMError("Label {} multiply defined.".format(tok))
+                if not all(ch.isalnum() or ch in '-_.' for ch in tok):
+                    raise MMError(("Only letters, digits, '_', '-', and '.' are allowed in labels: {}").format(tok))
                 label = tok
                 vprint(20, 'Label:', label)
                 if label == self.stop_label:


### PR DESCRIPTION
## Summary
- reject `$` characters in math symbol tokens
- keep label check for allowed characters

## Testing
- `python3 -m py_compile mmverify.py`
- `python3 mmverify.py test.mm -v1` *(custom test database)*
- `python3 mmverify.py badconst.mm -v0` *(fails: Character '$' not allowed in math symbol)*
- `python3 mmverify.py badlabel.mm -v0` *(error for undeclared variable due to label being split)*

------
https://chatgpt.com/codex/tasks/task_e_6842eab8b70c8328b825521d4fd3936c