### PR TITLE
Add Go-based Metamath verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,61 @@ Every core function called _after parsing_ in the read() function is implemented
 * mmverify-utils.metta - Contains the MeTTa implementations along with utility functions
 * mmverify.py - The original Python Metamath verifier by Raph Levien, modified with MeTTa integration code
 * examples/ - Contains examples of MeTTa interpretation of Metamath statements and their output
+* go/ - Minimal Metamath verifier written in Go
+
+## Go verifier
+
+The `go` directory contains a small Metamath verifier written in Go. It
+supports both normal and compressed proof formats.
+
+### Build
+
+```
+cd go
+go build -o mmverify
+```
+
+### Verify an `.mm` file
+
+```
+./mmverify ../examples/demo0.mm
+```
+
+The command prints `verification succeeded` when the database checks out.
+
+### Disjoint-variable failures
+
+The `examples` directory also contains files that intentionally break
+disjoint-variable requirements. Running the verifier on them reports the
+missing restrictions:
+
+```
+./mmverify ../examples/disjoint_bad_semigood.mm   # reports missing $d
+./mmverify ../examples/disjoint_bad_almostgood.mm # reports missing $d
+./mmverify ../examples/disjoint_bad_verybad.mm    # disjoint violation
+./mmverify ../examples/disjoint_bad_stillbad.mm   # disjoint violation
+```
+
+### File inclusion and token validation
+
+The Go verifier understands the `$[ file $]` inclusion directive and
+checks labels and math symbols for illegal characters:
+
+```
+./mmverify ../examples/demo0-includer.mm                # includes another file
+./mmverify ../examples/demo0-illegal-label-bad1.mm      # fails: illegal label
+./mmverify ../examples/demo0-dollar-in-math-symbol-bad1.mm # fails: $ in symbol
+```
+
+### Compressed proofs
+
+Compressed proofs are handled transparently. For example, the
+`examples/big-unifier.mm` database contains a theorem whose proof is
+given in compressed form:
+
+```
+./mmverify ../examples/big-unifier.mm
+```
 
 ---
 

--- a/examples/big-unifier.mm
+++ b/examples/big-unifier.mm
@@ -1,0 +1,68 @@
+$( big-unifier.mm - Version of 30-Aug-2008
+
+                             PUBLIC DOMAIN
+
+This file (specifically, the version of this file with the above date)
+has been placed in the Public Domain per the Creative Commons Public
+Domain Dedication.  http://creativecommons.org/licenses/publicdomain/
+
+The public domain release applies worldwide.  In case this is not
+legally possible, the right is granted to use the work for any purpose,
+without any conditions, unless such conditions are required by law.
+
+Norman Megill - http://metamath.org $)
+
+$(
+
+This file (big-unifier.mm) is a unification and substitution test for
+Metamath verifiers, where small input expressions blow up to thousands
+of symbols.  It is a translation of William McCune's "big-unifier.in"
+for the OTTER theorem prover:
+
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.in
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.out
+
+    Description:  "Examples of complicated substitutions in condensed
+        detachment.  These occur in Larry Wos's proofs that XCB is a single
+        axiom for EC."
+$)
+
+
+ $c wff |- e ( , ) $.
+ $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
+
+  wx $f wff x $. wy $f wff y $. wz $f wff z $. ww $f wff w $.
+  wv $f wff v $. wu $f wff u $. wv1 $f wff v1 $. wv2 $f wff v2 $.
+  wv3 $f wff v3 $. wv4 $f wff v4 $. wv5 $f wff v5 $. wv6 $f wff v6 $.
+  wv7 $f wff v7 $. wv8 $f wff v8 $. wv9 $f wff v9 $. wv10 $f wff v10 $.
+  wv11 $f wff v11 $.
+
+ $( The binary connective of the language "EC". $)
+ wi $a wff e ( x , y ) $.
+
+ ${
+   ax-mp.1 $e |- x $.
+   ax-mp.2 $e |- e ( x , y ) $.
+   $( The inference rule. $)
+   ax-mp $a |- y $.
+ $}
+
+ $( The first axiom. $)
+ ax-maj $a |- e ( e ( e ( e ( e ( x , e ( y , e ( e ( e ( e ( e ( z , e (
+   e ( e ( z , u ) , e ( v , u ) ) , v ) ) , e ( e ( w , e ( e ( e ( w , v6
+   ) , e ( v7 , v6 ) ) , v7 ) ) , y ) ) , v8 ) , e ( v9 , v8 ) ) , v9 ) ) )
+   , x ) , v10 ) , e ( v11 , v10 ) ) , v11 ) $.
+
+ $( The second axiom. $)
+ ax-min $a |- e ( e ( e ( e ( e ( e ( x , e ( e ( y , e ( e ( e ( y , z )
+   , e ( u , z ) ) , u ) ) , x ) ) , e ( v , e ( e ( e ( v , w ) , e ( v6 ,
+   w ) ) , v6 ) ) ) , v7 ) , v8 ) , e ( v7 , v8 ) ) , e ( v9 , e ( e ( e (
+   v9 , v10 ) , e ( v11 , v10 ) ) , v11 ) ) ) $.
+
+ $( A 3-step proof that applies ~ ax-mp to the two axioms.  The proof was
+    saved in compressed format with "save proof theorem1 /compressed" in
+    the metamath program. $)
+ theorem1 $p |- e ( e ( e ( x , e ( y , e ( e ( e ( y , z ) , e ( u , z ) )
+   , u ) ) ) , v ) , e ( x , v ) ) $=
+   ( wi ax-min ax-maj ax-mp ) ABBCFECFFEFFZFZKDFADFFZAFZFJMFFZKNJFFNFZFAO
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLHI $.

--- a/examples/demo0-dollar-in-math-symbol-bad1.mm
+++ b/examples/demo0-dollar-in-math-symbol-bad1.mm
@@ -1,0 +1,2 @@
+$( Contains a math symbol with a dollar sign $)
+$c te$st $.  

--- a/examples/demo0-illegal-label-bad1.mm
+++ b/examples/demo0-illegal-label-bad1.mm
@@ -1,0 +1,4 @@
+$( Contains an illegal label using a quote $)
+$c term |- $.
+$v t $.
+'bad $f term t $.

--- a/examples/demo0-includee.mm
+++ b/examples/demo0-includee.mm
@@ -1,0 +1,21 @@
+$( demo0-includee.mm -- portion of demo0.mm without theorem $)
+$c 0 + = -> ( ) term wff |- $.
+$v t r s P Q $.
+
+tt $f term t $.
+tr $f term r $.
+ts $f term s $.
+wp $f wff P $.
+wq $f wff Q $.
+
+tze $a term 0 $.
+tpl $a term ( t + r ) $.
+weq $a wff t = r $.
+wim $a wff ( P -> Q ) $.
+a1 $a |- ( t = r -> ( t = s -> r = s ) ) $.
+a2 $a |- ( t + 0 ) = t $.
+${
+  min $e |- P $.
+  maj $e |- ( P -> Q ) $.
+  mp $a |- Q $.
+$}

--- a/examples/demo0-includer.mm
+++ b/examples/demo0-includer.mm
@@ -1,0 +1,7 @@
+$( demo0-includer.mm -- uses file inclusion $)
+$[ demo0-includee.mm $]
+$( Prove a theorem $)
+th1 $p |- t = t $=
+  tt tze tpl tt weq tt tt weq tt a2 tt tze tpl
+  tt weq tt tze tpl tt weq tt tt weq wim tt a2
+  tt tze tpl tt tt a1 mp mp $.

--- a/examples/disjoint_bad_almostgood.mm
+++ b/examples/disjoint_bad_almostgood.mm
@@ -1,0 +1,18 @@
+$c formula |- ( ) $.
+
+$v x y z w $.
+xf $f formula x $.
+yf $f formula y $.
+zf $f formula z $.
+wf $f formula w $.
+combo $a formula ( x y ) $.
+${
+  $d x y $.
+  ax-1 $a |- ( x y ) $.
+$}
+${
+  $d x y $.
+  $d z w $.
+  almostgood $p |- ( ( x y ) ( z w ) ) $=
+    xf yf combo zf wf combo ax-1 $.
+$}

--- a/examples/disjoint_bad_semigood.mm
+++ b/examples/disjoint_bad_semigood.mm
@@ -1,0 +1,15 @@
+$c formula |- ( ) $.
+
+$v x y z w $.
+xf $f formula x $.
+yf $f formula y $.
+zf $f formula z $.
+wf $f formula w $.
+combo $a formula ( x y ) $.
+${
+  $d x y $.
+  ax-1 $a |- ( x y ) $.
+$}
+
+semigood $p |- ( ( x y ) ( z w ) ) $=
+  xf yf combo zf wf combo ax-1 $.

--- a/examples/disjoint_bad_stillbad.mm
+++ b/examples/disjoint_bad_stillbad.mm
@@ -1,0 +1,17 @@
+$c formula |- ( ) $.
+
+$v x y z w $.
+xf $f formula x $.
+yf $f formula y $.
+zf $f formula z $.
+wf $f formula w $.
+combo $a formula ( x y ) $.
+${
+  $d x y $.
+  ax-1 $a |- ( x y ) $.
+$}
+${
+  $d x y z $.
+  stillbad $p |- ( ( x y ) ( z x ) ) $=
+    xf yf combo zf xf combo ax-1 $.
+$}

--- a/examples/disjoint_bad_verybad.mm
+++ b/examples/disjoint_bad_verybad.mm
@@ -1,0 +1,15 @@
+$c formula |- ( ) $.
+
+$v x y z w $.
+xf $f formula x $.
+yf $f formula y $.
+zf $f formula z $.
+wf $f formula w $.
+combo $a formula ( x y ) $.
+${
+  $d x y $.
+  ax-1 $a |- ( x y ) $.
+$}
+
+verybad $p |- ( ( x y ) ( z x ) ) $=
+  xf yf combo zf xf combo ax-1 $.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,4 @@
+module mmverify
+
+go 1.20
+

--- a/go/mmverify.go
+++ b/go/mmverify.go
@@ -1,0 +1,617 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+type Statement struct {
+	kind  string
+	label string
+	expr  []string
+	hyps  []string // all hypotheses (floating followed by essential)
+	fHyps []string // floating hypothesis labels
+	eHyps []string // essential hypothesis labels
+	dv    [][2]string
+	proof []string
+}
+
+type Frame struct {
+	floating  []string
+	essential []string
+	dvPairs   [][2]string
+}
+
+var (
+	constants = map[string]bool{}
+	variables = map[string]bool{}
+	labels    = map[string]*Statement{}
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: mmverify <file.mm>")
+		os.Exit(1)
+	}
+	if err := parseFile(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "verify failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("verification succeeded")
+}
+
+// tokenizer
+
+type tokenizer struct {
+	r *bufio.Reader
+}
+
+func newTokenizer(input string) *tokenizer {
+	return &tokenizer{bufio.NewReader(strings.NewReader(input))}
+}
+
+func (t *tokenizer) next() (string, error) {
+	for {
+		ch, _, err := t.r.ReadRune()
+		if err == io.EOF {
+			return "", io.EOF
+		}
+		if unicode.IsSpace(ch) {
+			continue
+		}
+		if ch == '$' {
+			ch2, _, err := t.r.ReadRune()
+			if err != nil {
+				return "", err
+			}
+			return "$" + string(ch2), nil
+		}
+		tok := []rune{ch}
+		for {
+			ch, _, err := t.r.ReadRune()
+			if err == io.EOF {
+				return string(tok), nil
+			}
+			if unicode.IsSpace(ch) {
+				return string(tok), nil
+			}
+			if ch == '$' {
+				t.r.UnreadRune()
+				return string(tok), nil
+			}
+			tok = append(tok, ch)
+		}
+	}
+}
+
+// parser and verifier
+
+type fileTok struct {
+	tz  *tokenizer
+	dir string
+}
+
+func parseFile(path string) error {
+	frames := []*Frame{{}}
+	stack := []fileTok{}
+	push := func(p string) error {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		stack = append(stack, fileTok{tz: newTokenizer(string(data)), dir: filepath.Dir(p)})
+		return nil
+	}
+	if err := push(path); err != nil {
+		return err
+	}
+	next := func() (string, error) {
+		for len(stack) > 0 {
+			tok, err := stack[len(stack)-1].tz.next()
+			if err == io.EOF {
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			return tok, err
+		}
+		return "", io.EOF
+	}
+	for {
+		tok, err := next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		switch tok {
+		case "$(":
+			if err := skipComment(next); err != nil {
+				return err
+			}
+		case "$[":
+			fname, err := next()
+			if err != nil {
+				return err
+			}
+			end, err := next()
+			if err != nil {
+				return err
+			}
+			if end != "$]" {
+				return fmt.Errorf("expected $] after include filename")
+			}
+			curdir := stack[len(stack)-1].dir
+			if err := push(filepath.Join(curdir, fname)); err != nil {
+				return err
+			}
+		case "$c":
+			for {
+				t, err := next()
+				if err != nil {
+					return err
+				}
+				if t == "$(" {
+					if err := skipComment(next); err != nil {
+						return err
+					}
+					continue
+				}
+				if t == "$." {
+					break
+				}
+				if strings.HasPrefix(t, "$") {
+					return fmt.Errorf("invalid math symbol %s", t)
+				}
+				constants[t] = true
+			}
+		case "$v":
+			for {
+				t, err := next()
+				if err != nil {
+					return err
+				}
+				if t == "$(" {
+					if err := skipComment(next); err != nil {
+						return err
+					}
+					continue
+				}
+				if t == "$." {
+					break
+				}
+				if strings.HasPrefix(t, "$") {
+					return fmt.Errorf("invalid math symbol %s", t)
+				}
+				variables[t] = true
+			}
+		case "$d":
+			vars := []string{}
+			for {
+				t, err := next()
+				if err != nil {
+					return err
+				}
+				if t == "$(" {
+					if err := skipComment(next); err != nil {
+						return err
+					}
+					continue
+				}
+				if t == "$." {
+					break
+				}
+				vars = append(vars, t)
+			}
+			cf := frames[len(frames)-1]
+			for i := 0; i < len(vars); i++ {
+				for j := i + 1; j < len(vars); j++ {
+					cf.dvPairs = append(cf.dvPairs, [2]string{vars[i], vars[j]})
+				}
+			}
+		case "${":
+			frames = append(frames, &Frame{})
+		case "$}":
+			frames = frames[:len(frames)-1]
+		default:
+			label := tok
+			if !isValidLabel(label) {
+				return fmt.Errorf("illegal label %s", label)
+			}
+			stype, err := next()
+			if err != nil {
+				return err
+			}
+			switch stype {
+			case "$f":
+				typecode, _ := next()
+				varTok, _ := next()
+				if term, _ := next(); term != "$." {
+					return fmt.Errorf("expected $. after $f")
+				}
+				stmt := &Statement{kind: "$f", label: label, expr: []string{typecode, varTok}}
+				labels[label] = stmt
+				cf := frames[len(frames)-1]
+				cf.floating = append(cf.floating, label)
+			case "$e":
+				typecode, _ := next()
+				expr := []string{typecode}
+				for {
+					t, err := next()
+					if err != nil {
+						return err
+					}
+					if t == "$(" {
+						if err := skipComment(next); err != nil {
+							return err
+						}
+						continue
+					}
+					if t == "$." {
+						break
+					}
+					expr = append(expr, t)
+				}
+				stmt := &Statement{kind: "$e", label: label, expr: expr}
+				labels[label] = stmt
+				cf := frames[len(frames)-1]
+				cf.essential = append(cf.essential, label)
+			case "$a":
+				typecode, _ := next()
+				expr := []string{typecode}
+				for {
+					t, err := next()
+					if err != nil {
+						return err
+					}
+					if t == "$(" {
+						if err := skipComment(next); err != nil {
+							return err
+						}
+						continue
+					}
+					if t == "$." {
+						break
+					}
+					expr = append(expr, t)
+				}
+				fHyps, eHyps := gatherHyps(frames, expr)
+				dv := gatherDVs(frames)
+				stmt := &Statement{kind: "$a", label: label, expr: expr, hyps: append(append([]string{}, fHyps...), eHyps...), fHyps: fHyps, eHyps: eHyps, dv: dv}
+				labels[label] = stmt
+			case "$p":
+				typecode, _ := next()
+				expr := []string{typecode}
+				for {
+					t, err := next()
+					if err != nil {
+						return err
+					}
+					if t == "$(" {
+						if err := skipComment(next); err != nil {
+							return err
+						}
+						continue
+					}
+					if t == "$=" {
+						break
+					}
+					expr = append(expr, t)
+				}
+				proof := []string{}
+				for {
+					t, err := next()
+					if err != nil {
+						return err
+					}
+					if t == "$(" {
+						if err := skipComment(next); err != nil {
+							return err
+						}
+						continue
+					}
+					if t == "$." {
+						break
+					}
+					proof = append(proof, t)
+				}
+				fHyps, eHyps := gatherHyps(frames, expr)
+				dv := gatherDVs(frames)
+				stmt := &Statement{kind: "$p", label: label, expr: expr, hyps: append(append([]string{}, fHyps...), eHyps...), fHyps: fHyps, eHyps: eHyps, dv: dv, proof: proof}
+				labels[label] = stmt
+				if err := verify(stmt); err != nil {
+					return fmt.Errorf("%s: %v", label, err)
+				}
+			default:
+				return fmt.Errorf("unknown statement type %s", stype)
+			}
+		}
+	}
+}
+
+func isValidLabel(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func skipComment(next func() (string, error)) error {
+	for {
+		t, err := next()
+		if err != nil {
+			return err
+		}
+		if t == "$)" {
+			return nil
+		}
+	}
+}
+
+func gatherHyps(frames []*Frame, expr []string) (fHyps []string, eHyps []string) {
+	varsNeeded := map[string]bool{}
+	for _, tok := range expr[1:] {
+		if variables[tok] {
+			varsNeeded[tok] = true
+		}
+	}
+	for _, fr := range frames {
+		for _, elabel := range fr.essential {
+			e := labels[elabel]
+			for _, tok := range e.expr[1:] {
+				if variables[tok] {
+					varsNeeded[tok] = true
+				}
+			}
+		}
+	}
+	for _, fr := range frames {
+		for _, flabel := range fr.floating {
+			v := labels[flabel].expr[1]
+			if varsNeeded[v] {
+				fHyps = append(fHyps, flabel)
+			}
+		}
+		eHyps = append(eHyps, fr.essential...)
+	}
+	return
+}
+
+func gatherDVs(frames []*Frame) [][2]string {
+	var dv [][2]string
+	for _, fr := range frames {
+		dv = append(dv, fr.dvPairs...)
+	}
+	return dv
+}
+
+// verification
+
+type substMap map[string][]string
+
+func verify(stmt *Statement) error {
+	if len(stmt.proof) > 0 && stmt.proof[0] == "(" {
+		return verifyCompressed(stmt)
+	}
+	return verifyNormal(stmt)
+}
+
+func verifyNormal(stmt *Statement) error {
+	allowed := map[[2]string]bool{}
+	for _, pair := range stmt.dv {
+		allowed[[2]string{pair[0], pair[1]}] = true
+		allowed[[2]string{pair[1], pair[0]}] = true
+	}
+	needed := map[[2]string]bool{}
+	stack := [][]string{}
+	for _, lbl := range stmt.proof {
+		st, ok := labels[lbl]
+		if !ok {
+			return fmt.Errorf("unknown label %s", lbl)
+		}
+		if err := applyStep(st, &stack, needed); err != nil {
+			return fmt.Errorf("%s: %v", lbl, err)
+		}
+	}
+	if len(stack) != 1 {
+		return errors.New("stack not singleton at end")
+	}
+	if !exprEqual(stack[0], stmt.expr) {
+		return errors.New("final expression mismatch")
+	}
+	for pair := range needed {
+		if !allowed[pair] {
+			return fmt.Errorf("missing $d %s %s", pair[0], pair[1])
+		}
+	}
+	return nil
+}
+
+func verifyCompressed(stmt *Statement) error {
+	allowed := map[[2]string]bool{}
+	for _, pair := range stmt.dv {
+		allowed[[2]string{pair[0], pair[1]}] = true
+		allowed[[2]string{pair[1], pair[0]}] = true
+	}
+	needed := map[[2]string]bool{}
+	// Build label list from hypotheses and explicit labels
+	labelsList := append(append([]string{}, stmt.fHyps...), stmt.eHyps...)
+	idx := 1
+	for idx < len(stmt.proof) && stmt.proof[idx] != ")" {
+		labelsList = append(labelsList, stmt.proof[idx])
+		idx++
+	}
+	if idx >= len(stmt.proof) || stmt.proof[idx] != ")" {
+		return errors.New("unterminated label block in compressed proof")
+	}
+	idx++
+	proofStr := strings.Join(stmt.proof[idx:], "")
+	ints := []int{}
+	cur := 0
+	for _, ch := range proofStr {
+		switch {
+		case ch == 'Z':
+			ints = append(ints, -1)
+		case 'A' <= ch && ch <= 'T':
+			ints = append(ints, 20*cur+int(ch-'A'))
+			cur = 0
+		case 'U' <= ch && ch <= 'Y':
+			cur = 5*cur + int(ch-'U') + 1
+		default:
+			return fmt.Errorf("bad compressed proof char %c", ch)
+		}
+	}
+	stack := [][]string{}
+	saved := [][]string{}
+	for _, n := range ints {
+		if n == -1 {
+			if len(stack) == 0 {
+				return errors.New("nothing to save")
+			}
+			saved = append(saved, stack[len(stack)-1])
+			continue
+		}
+		if n < len(labelsList) {
+			lbl := labelsList[n]
+			st, ok := labels[lbl]
+			if !ok {
+				return fmt.Errorf("unknown label %s", lbl)
+			}
+			if err := applyStep(st, &stack, needed); err != nil {
+				return fmt.Errorf("%s: %v", lbl, err)
+			}
+			continue
+		}
+		idx := n - len(labelsList)
+		if idx >= len(saved) {
+			return fmt.Errorf("invalid saved step %d", n)
+		}
+		tmp := &Statement{kind: "$a", expr: saved[idx]}
+		if err := applyStep(tmp, &stack, needed); err != nil {
+			return err
+		}
+	}
+	if len(stack) != 1 {
+		return errors.New("stack not singleton at end")
+	}
+	if !exprEqual(stack[0], stmt.expr) {
+		return errors.New("final expression mismatch")
+	}
+	for pair := range needed {
+		if !allowed[pair] {
+			return fmt.Errorf("missing $d %s %s", pair[0], pair[1])
+		}
+	}
+	return nil
+}
+
+func applyStep(st *Statement, stack *[][]string, needed map[[2]string]bool) error {
+	switch st.kind {
+	case "$f", "$e":
+		*stack = append(*stack, st.expr)
+		return nil
+	case "$a", "$p":
+		n := len(st.hyps)
+		if len(*stack) < n {
+			return errors.New("stack underflow")
+		}
+		args := (*stack)[len(*stack)-n:]
+		*stack = (*stack)[:len(*stack)-n]
+		subst := substMap{}
+		for i, hlabel := range st.hyps {
+			h := labels[hlabel]
+			arg := args[i]
+			if h.kind == "$f" {
+				v := h.expr[1]
+				if ex, ok := subst[v]; ok {
+					if !exprEqual(ex, arg) {
+						return fmt.Errorf("mismatch for %s", v)
+					}
+				} else {
+					subst[v] = arg
+				}
+			} else {
+				expected := substitute(h.expr, subst)
+				if !exprEqual(expected, arg) {
+					return fmt.Errorf("hypothesis %s mismatch", hlabel)
+				}
+			}
+		}
+		for _, pair := range st.dv {
+			a, aok := subst[pair[0]]
+			b, bok := subst[pair[1]]
+			if !aok || !bok {
+				continue
+			}
+			av := varsIn(a)
+			bv := varsIn(b)
+			if intersects(av, bv) {
+				return fmt.Errorf("disjoint variable violation %s %s", pair[0], pair[1])
+			}
+			for x := range av {
+				for y := range bv {
+					needed[[2]string{x, y}] = true
+				}
+			}
+		}
+		res := substitute(st.expr, subst)
+		*stack = append(*stack, res)
+		return nil
+	default:
+		return fmt.Errorf("bad statement kind %s", st.kind)
+	}
+}
+
+func substitute(expr []string, subst substMap) []string {
+	out := []string{expr[0]}
+	for _, tok := range expr[1:] {
+		if rep, ok := subst[tok]; ok {
+			out = append(out, rep[1:]...)
+		} else {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+func exprEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func varsIn(expr []string) map[string]bool {
+	m := map[string]bool{}
+	for _, tok := range expr[1:] {
+		if variables[tok] {
+			m[tok] = true
+		}
+	}
+	return m
+}
+
+func intersects(a, b map[string]bool) bool {
+	for k := range a {
+		if b[k] {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
ChatGPT Codex:

## Summary
- extend Go verifier with `$[ file $]` inclusion handling
- validate label names and forbid `$` in math symbols
- document and supply negative examples for inclusion and token errors
- support compressed proof format and propagate hypothesis lists

## Testing
- `go build -o mmverify mmverify.go`
- `go/mmverify examples/big-unifier.mm`
- `go/mmverify examples/disjoint_bad_semigood.mm` *(fails: missing $d)*
- `go/mmverify examples/demo0-includer.mm`


------
https://chatgpt.com/codex/tasks/task_e_68c00059dcdc8328b3b7434fb78f31ae

Zar: 

All tests in the metamath test suite seem to pass:
./run-testsuite test-mmverifygo
ok - anatomy.mm Simple 'anatomy' test
ok - anatomy-bad1.mm Simple incorrect 'anatomy' test 
ok - anatomy-bad2.mm Simple incorrect 'anatomy' test 
ok - anatomy-bad3.mm Simple incorrect 'anatomy' test 
ok - big-unifier.mm 
ok - big-unifier-bad1.mm 
ok - big-unifier-bad2.mm 
ok - big-unifier-bad3.mm 
ok - demo0.mm 
ok - demo0-bad1.mm 
ok - demo0-includer.mm Test simple file inclusion
ok - emptyline.mm A file with one empty line
ok - hol.mm 
ok - iset.mm 
ok - miu.mm 
ok - nf.mm 
ok - peano-fixed.mm 
ok - ql.mm 
ok - set.2010-08-29.mm 
ok - set.mm 
ok - set-dist-bad1.mm 
ok - out-of-range-saved-step-bad1.mm Simple test for out of range compressed proof step references
ok - demo0-illegal-label-bad1.mm Simple test for illegal label names
ok - demo0-dollar-in-math-symbol-bad1.mm Simple test for $ in math symbols
All tests passed for driver test-mmverifygo
