### PR TITLE
Align include handling and tests with Metamath spec

### DIFF
--- a/goverify/mmverify.go
+++ b/goverify/mmverify.go
@@ -77,20 +77,6 @@ func newVError(code ErrCode, file string, line, col int, format string, args ...
 // SECTION: Core Data Structures
 // ═══════════════════════════════════════════════════════════════
 
-// Small, intentional micro-optimizations / clarity aids.
-const (
-	initialProofCapacity = 16
-)
-
-// Domain aliases for readability (no runtime cost).
-type (
-	Label     = string
-	Variable  = string
-	Typecode  = string
-	Expression = []string
-	Proof      = []string
-)
-
 type Statement struct {
 	kind       string
 	label      Label
@@ -152,18 +138,10 @@ type FileContext struct {
 // Parser drives tokenization across nested include files.
 // INVARIANTS:
 //   - stack[i].path is always an absolute, canonical path
-//   - lastComment is true iff the most recently produced token was a $( ... $) comment
+//   - seen[path] is true iff the file has been processed at least once
 type Parser struct {
-	stack       []*FileContext
-	lastComment bool
-}
-
-func (p *Parser) ensureNotAfterComment(tok *Token) error {
-	if p.lastComment {
-		p.lastComment = false
-		return newVError(EWhitespace, tok.file, tok.line, tok.col, "token must be separated by whitespace after $) (spec §4.4.1)")
-	}
-	return nil
+	stack []*FileContext
+	seen  map[string]bool
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -199,7 +177,7 @@ func run(path string, traceSteps, explain bool) error {
 		explain:     explain,
 	}
 	db.pushFrame()
-	parser := &Parser{stack: []*FileContext{}}
+	parser := &Parser{stack: []*FileContext{}, seen: map[string]bool{}}
 	if err := parser.pushFile(path); err != nil {
 		return err
 	}
@@ -213,9 +191,12 @@ func run(path string, traceSteps, explain bool) error {
 		}
 		switch tok.value {
 		case "$[":
-			// Include resolution (Spec §4.1.2): resolve relative paths, detect cycles,
-			// and ignore recursive includes instead of erroring like metamath.exe.
+			// Include resolution (Spec §4.1.2): includes are allowed only in the
+			// outermost scope and each file is processed at most once.
 			cur := parser.currentFile()
+			if cur.blockDepth > 0 {
+				return parser.errorf(tok, "include statements are only allowed in the outermost scope (spec §4.1.2)")
+			}
 			fnameTok, err := parser.nextToken()
 			if err != nil {
 				return err
@@ -238,11 +219,9 @@ func run(path string, traceSteps, explain bool) error {
 			if err != nil {
 				return fmt.Errorf("%s:%d:%d: unable to resolve include path: %v", tok.file, tok.line, tok.col, err)
 			}
-			if parser.isOnStack(abs) {
-				// Spec §4.1.2: "A file may include itself...will simply be ignored".
-				// The canonical-path comparison detects self-includes and longer cycles
-				// (e.g. A → B → A) so we can skip them without recursing forever.
-				db.warnings = append(db.warnings, fmt.Sprintf("%s ignored (code=%s)", abs, EIncludeCycle))
+			abs = filepath.Clean(abs)
+			if parser.seen[abs] {
+				// Subsequent references to the same file are ignored (Spec §4.1.2).
 				continue
 			}
 			if err := parser.pushFile(abs); err != nil {
@@ -261,6 +240,9 @@ func run(path string, traceSteps, explain bool) error {
 				return parser.errorf(tok, err.Error())
 			}
 		case "$c":
+			if len(db.frameStack) != 1 {
+				return parser.errorf(tok, "$c statements are only allowed in the outermost block (Spec Section 4.1.3)")
+			}
 			if err := db.parseConstants(parser); err != nil {
 				return err
 			}
@@ -368,11 +350,6 @@ func (db *Database) parseConstants(parser *Parser) error {
 		if tok.value == "$." {
 			return nil
 		}
-		if err := parser.ensureNotAfterComment(tok); err != nil {
-			return err
-		if parser.lastComment {
-			return parser.ensureNoComment(tok, "$c statements")
-		}
 		if strings.HasPrefix(tok.value, "$") {
 			return parser.errorf(tok, "invalid constant token '%s'", tok.value)
 		}
@@ -399,11 +376,6 @@ func (db *Database) parseVariables(parser *Parser) error {
 		}
 		if tok.value == "$." {
 			return nil
-		}
-		if err := parser.ensureNotAfterComment(tok); err != nil {
-			return err
-		if parser.lastComment {
-			return parser.ensureNoComment(tok, "$v statements")
 		}
 		if strings.HasPrefix(tok.value, "$") {
 			return parser.errorf(tok, "invalid variable token '%s'", tok.value)
@@ -436,11 +408,6 @@ func (db *Database) parseDisjoint(parser *Parser) error {
 		if tok.value == "$." {
 			break
 		}
-		if err := parser.ensureNotAfterComment(tok); err != nil {
-			return err
-		if parser.lastComment {
-			return parser.ensureNoComment(tok, "$d statements")
-		}
 		if !db.isVarActive(tok.value) {
 			// SPEC COMPLIANCE: Per §4.2.5, every variable in a $d must be active in the current frame.
 			return parser.errorf(tok, "disjoint variable '%s' is not an active variable", tok.value)
@@ -469,22 +436,12 @@ func (db *Database) parseFloating(label string, parser *Parser) error {
 	if err != nil {
 		return err
 	}
-	if err := parser.ensureNotAfterComment(typeTok); err != nil {
-		return err
-	if parser.lastComment {
-		return parser.ensureNoComment(typeTok, "$f statements")
-	}
 	if !db.constants[typeTok.value] {
 		return parser.errorf(typeTok, "typecode '%s' is not a declared constant", typeTok.value)
 	}
 	varTok, err := parser.nextToken()
 	if err != nil {
 		return err
-	}
-	if err := parser.ensureNotAfterComment(varTok); err != nil {
-		return err
-	if parser.lastComment {
-		return parser.ensureNoComment(varTok, "$f statements")
 	}
 	if !db.isVarActive(varTok.value) {
 		return parser.errorf(varTok, "variable '%s' is not active", varTok.value)
@@ -567,11 +524,6 @@ func (db *Database) readExpression(endToken string, parser *Parser) (*Statement,
 	if err != nil {
 		return nil, err
 	}
-	if err := parser.ensureNotAfterComment(typeTok); err != nil {
-		return nil, err
-	if parser.lastComment {
-		return nil, parser.ensureNoComment(typeTok, "statements")
-	}
 	if !db.constants[typeTok.value] {
 		return nil, parser.errorf(typeTok, "typecode '%s' is not a declared constant", typeTok.value)
 	}
@@ -584,11 +536,6 @@ func (db *Database) readExpression(endToken string, parser *Parser) (*Statement,
 		}
 		if tok.value == endToken {
 			break
-		}
-		if err := parser.ensureNotAfterComment(tok); err != nil {
-			return nil, err
-		if parser.lastComment {
-			return nil, parser.ensureNoComment(tok, "statements")
 		}
 		if strings.HasPrefix(tok.value, "$") {
 			return nil, parser.errorf(tok, "unexpected control token '%s' in expression", tok.value)
@@ -611,8 +558,6 @@ func (db *Database) readExpression(endToken string, parser *Parser) (*Statement,
 
 func (db *Database) readProof(parser *Parser) (Proof, error) {
 	proof := make(Proof, 0, initialProofCap)
-func (db *Database) readProof(parser *Parser) ([]string, error) {
-	proof := make([]string, 0, initialProofCapacity)
 	for {
 		tok, err := parser.nextToken()
 		if err != nil {
@@ -620,11 +565,6 @@ func (db *Database) readProof(parser *Parser) ([]string, error) {
 		}
 		if tok.value == "$." {
 			break
-		}
-		if err := parser.ensureNotAfterComment(tok); err != nil {
-			return nil, err
-		if parser.lastComment {
-			return nil, parser.ensureNoComment(tok, "proofs")
 		}
 		proof = append(proof, tok.value)
 	}
@@ -1124,6 +1064,7 @@ func (p *Parser) pushFile(path string) error {
 	if err != nil {
 		return err
 	}
+	abs = filepath.Clean(abs)
 	data, err := os.ReadFile(abs)
 	if err != nil {
 		return err
@@ -1144,6 +1085,10 @@ func (p *Parser) pushFile(path string) error {
 		blockDepth:      0,
 	}
 	p.stack = append(p.stack, ctx)
+	if p.seen == nil {
+		p.seen = map[string]bool{}
+	}
+	p.seen[abs] = true
 	return nil
 }
 
@@ -1151,26 +1096,7 @@ func (p *Parser) currentFile() *FileContext {
 	return p.stack[len(p.stack)-1]
 }
 
-// ensureNoComment raises a location-aware error if the most recent token was a comment.
-// We keep messages centralized so humans can audit where comments are disallowed.
-func (p *Parser) ensureNoComment(tok *Token, where string) error {
-	if p.lastComment {
-		return p.errorf(tok, "comments are not allowed inside %s", where)
-	}
-	return nil
-}
-
-func (p *Parser) isOnStack(path string) bool {
-	for _, ctx := range p.stack {
-		if ctx.path == path {
-			return true
-		}
-	}
-	return false
-}
-
 func (p *Parser) nextToken() (*Token, error) {
-	p.lastComment = false
 	for {
 		if len(p.stack) == 0 {
 			return nil, io.EOF
@@ -1206,10 +1132,9 @@ func (p *Parser) nextToken() (*Token, error) {
 				if err := ctx.skipComment(); err != nil {
 					return nil, err
 				}
-				p.lastComment = true
 				if ctx.pos < len(ctx.data) {
 					if !isWhitespace(ctx.data[ctx.pos]) {
-						return nil, fmt.Errorf("%s:%d:%d: missing whitespace after comment", ctx.path, ctx.line, ctx.col)
+						return nil, newVError(EWhitespace, ctx.path, ctx.line, ctx.col, "missing whitespace after comment (spec §4.1.2)")
 					}
 				}
 				ctx.afterWhitespace = true

--- a/goverify/unit-tests/UNIT_TESTS_CATALOGUE.md
+++ b/goverify/unit-tests/UNIT_TESTS_CATALOGUE.md
@@ -426,27 +426,22 @@ $}
 
 ---
 
-## Test 17: Include Scope Violation
+## Test 17: Include Inside Block (Forbidden)
 
-**Description:** Include statement inside block, then try to use included content outside the block
+**Description:** Include command appears between `${` and `$}`.
 
-**Background:**
-- metamath.exe accepts `$[ $]` inside blocks (scopes content to block)
-- Spec says "should only exist at outermost scope" (recommendation, not hard requirement)
-- See SPEC_DIVERGENCES.md for details
+**Spec Clause:** Section 4.1.2 — "$[ ... $]" is only allowed in the outermost scope and must not occur between `${` and `$}`.
 
 **Invalid example:**
 ```metamath
 ${
-  $[ inner.mm $]  ← Include inside block
+  $[ inner.mm $]  ← Illegal: include inside a block
 $}
-$( Try to use inner.mm content here $)
-th $p |- y $= wy ax-inner $.  ← ERROR: out of scope!
 ```
 
-**Valid:** Include at outermost scope, or use content within the same block
+**Valid:** Place `$[ ... $]` only at the top level of the database.
 
-**Why it matters:** Scope rules must be enforced consistently
+**Why it matters:** Ignoring this rule silently reintroduces symbols in inner scopes and breaks the spec's preprocessing guarantees.
 
 **Test database:**
 ```metamath
@@ -455,14 +450,11 @@ $v x $.
 wx $f wff x $.
 
 ${
-  $[ /tmp/inner_test17.mm $]
+  $[ ./inner_test17.mm $]
 $}
-
-$( ax-inner is not active here $)
-th2 $p |- y $= wy ax-inner $.
 ```
 
-**Expected:** Reject with scope error
+**Expected:** Reject with an error referencing the outermost scope requirement.
 
 **File:** `test17_include_scope_violation.mm`
 
@@ -749,24 +741,22 @@ bad $p |- y $= f1 ax $.  ← Wrong conclusion
 
 ## Test 28: Self-Include
 
-**Description:** File includes itself, causing duplicate declarations
+**Description:** File includes itself; spec says this must be ignored.
 
 **Background:**
-- Self-include is NOT ignored (unlike duplicate includes)
-- File is read twice, causing all declarations to duplicate
-- See SPEC_DIVERGENCES.md for discussion
+- Spec Section 4.1.2: "A file may include itself...will simply be ignored."
+- The include preprocessor treats subsequent references to the same file as whitespace.
+- Implementations should therefore accept a database that includes itself once.
 
-**Invalid example:**
+**Invalid example:** None — the spec defines the behaviour as acceptance with no effect.
+
+**Valid:**
 ```metamath
 $c wff $.
-$[ THIS_FILE.mm $]  ← Includes itself!
+$[ THIS_FILE.mm $]  ← Include is ignored
 ```
 
-**Result:** `$c wff $.` appears twice → duplicate declaration error
-
-**Valid:** Files can only include OTHER files
-
-**Why it matters:** Prevents duplicate declarations and potential infinite loops
+**Why it matters:** Guarantees that self-references do not trigger duplicate declarations or infinite loops.
 
 **Test database (placeholder path replaced at runtime):**
 ```metamath
@@ -776,7 +766,7 @@ $[ __SELF__ $]
 
 **Note:** The `__SELF__` placeholder is replaced with the actual temp file path by the test runner, enabling self-inclusion.
 
-**Expected:** Reject with "symbol already declared" error
+**Expected:** Accept (no error); inclusion acts as whitespace.
 
 **File:** `test28_self_include.mm`
 
@@ -812,7 +802,7 @@ See individual test files:
 | 14 | Type | Missing $f | High |
 | 15 | Type | Multiple $f | High |
 | 16 | Type | Conflicting types | High |
-| 17 | Include | Recursive include | High |
+| 17 | Include | Include inside block | High |
 | 18 | Syntactic | Comment in statement | Medium |
 | 19 | Proof | Compressed overflow | Low |
 | 20 | Proof | Unknown step ? | Special |

--- a/goverify/unit-tests/run_unit_tests.py
+++ b/goverify/unit-tests/run_unit_tests.py
@@ -195,18 +195,15 @@ $}""",
     },
 
     17: {
-        "name": "Include scope violation (use included content outside block)",
+        "name": "Include inside block (not outermost scope)",
         "database": """$c wff |- $.
 $v x $.
 wx $f wff x $.
 ${
-  $[ /tmp/inner_test17.mm $]
-$}
-$( Try to use ax-inner outside the block - scope violation $)
-th2 $p |- y $= wy ax-inner $.""",
+  $[ inner.mm $]
+$}""",
         "should_reject": True,
-        "error_keywords": ["scope", "inactive", "not active", "symbol"],
-        "setup": lambda: create_inner_test17(),
+        "error_keywords": ["include", "outermost", "scope", "block"],
     },
 
     18: {
@@ -329,7 +326,7 @@ bad $p |- ( z -> z ) $= wfz wfz axxy $.""",
         "name": "Self-include",
         "database": """$c wff $.
 $[ __SELF__ $]""",
-        "should_reject": False,  # Spec §4.1.2: "will simply be ignored"
+        "should_reject": False,  # Spec Section 4.1.2: "will simply be ignored"
         "error_keywords": [],
         "note": "Spec says ignore. metamath.exe rejects (spec divergence).",
         "is_spec_divergence": True,
@@ -452,7 +449,7 @@ ax $a |- x $.
 $( Compressed proof A B with whitespace: spaces, newlines, tabs $)
 th $p |- x $= ( ax )   A
   B   $.""",
-        "should_reject": False,  # Should accept (whitespace ignored per spec §4.4.2)
+        "should_reject": False,  # Should accept (whitespace ignored per Spec Section 4.4.2)
         "error_keywords": [],
         "note": "Tests that whitespace between valid compressed proof steps is ignored",
     },
@@ -505,14 +502,6 @@ def load_tests_from_files() -> Dict[int, dict]:
 # =============================================================================
 # Helper Functions
 # =============================================================================
-
-def create_inner_test17():
-    """Create inner file with active content for Test 17."""
-    path = "/tmp/inner_test17.mm"
-    with open(path, 'w') as f:
-        f.write("$v y $.\nwy $f wff y $.\nax-inner $a |- y $.\n")
-    return path
-
 
 def run_verifier(verifier_path: str, database_or_path: str, is_file: bool = False) -> Tuple[bool, str]:
     """

--- a/goverify/unit-tests/test17_include_inside_block_(not_outermost_scope).mm
+++ b/goverify/unit-tests/test17_include_inside_block_(not_outermost_scope).mm
@@ -1,8 +1,0 @@
-$( Unit Test 17: Include inside block (not outermost scope) $)
-$( Should reject: True $)
-
-$c wff $.
-${
-  $[ /tmp/inner.mm $]
-  $v x $.
-$}

--- a/goverify/unit-tests/test17_include_scope_violation.mm
+++ b/goverify/unit-tests/test17_include_scope_violation.mm
@@ -1,17 +1,11 @@
-$( Unit Test 17: Include inside block with scope violation $)
-$( Should reject: True $)
+$( Unit Test 17: Include inside block (not outermost scope) $)
+$( Should reject: True - Spec Section 4.1.2 forbids $[ ... $] between ${ and $} $)
 
 $c wff |- $.
 $v x $.
 wx $f wff x $.
 
 ${
-  $( Include inside block - contents scoped to block $)
+  $( Include is placed inside the block - this is illegal per spec $)
   $[ ./inner_test17.mm $]
-
-  $( This would work - using inside the block $)
-  $( th1 $p |- y $= wy ax-inner $. $)
 $}
-
-$( Try to use ax-inner outside the block - SCOPE VIOLATION $)
-th2 $p |- y $= wy ax-inner $.

--- a/goverify/unit-tests/test40_include_scope_correct_inner.mm
+++ b/goverify/unit-tests/test40_include_scope_correct_inner.mm
@@ -1,5 +1,5 @@
-$( Unit Test 40 Inner: Include inside block - correct usage $)
-$( Declarations in this file are scoped to the including block $)
+$( Unit Test 40 Helper: Provides declarations for include tests $)
+$( Contains statements that would be spliced if includes were allowed $)
 
 $v y $.
 wy $f wff y $.

--- a/goverify/unit-tests/test40_include_scope_correct_outer.mm
+++ b/goverify/unit-tests/test40_include_scope_correct_outer.mm
@@ -1,18 +1,9 @@
-$( Unit Test 40: Include inside block - correct usage $)
-$( Should reject: False - using included content inside block is valid $)
+$( Unit Test 40: Include inside statement (forbidden) $)
+$( Should reject: True - Spec Section 4.1.2 forbids $[ ... $] inside statements $)
 
 $c wff |- $.
 $v x $.
 wx $f wff x $.
 ax-x $a |- x $.
 
-${
-  $( Include inside block $)
-  $[ ./test40_include_scope_correct_inner.mm $]
-
-  $( Use included axiom INSIDE the block - this should work $)
-  th1 $p |- y $= wy ax-inner $.
-$}
-
-$( Outside the block, only x is available $)
-th2 $p |- x $= wx ax-x $.
+th-bad $p |- x $= $[ ./test40_include_scope_correct_inner.mm $] $.

--- a/goverify/unit-tests/test46_duplicate_include_main.mm
+++ b/goverify/unit-tests/test46_duplicate_include_main.mm
@@ -1,22 +1,13 @@
-$( Unit Test 46: Duplicate include in different scopes $)
-$( Should reject: False - second include is ignored per spec Section 4.4.4 $)
-$( Spec: "only the first reference to this common file will be read in" $)
+$( Unit Test 46: Duplicate include at outermost scope $)
+$( Should reject: False - second include is ignored per Spec Section 4.1.2 $)
 
 $c wff |- $.
 
-${
-  $( First include: processes the file $)
-  $[ ./test46_duplicate_include_helper.mm $]
+$( First include: processes the helper file $)
+$[ ./test46_duplicate_include_helper.mm $]
 
-  $( Use the included content $)
-  th1 $p |- y $= wy ax-y $.
-$}
+$( Second include: must be ignored, avoiding duplicate declarations $)
+$[ ./test46_duplicate_include_helper.mm $]
 
-${
-  $( Second include: should be ignored as whitespace $)
-  $[ ./test46_duplicate_include_helper.mm $]
-
-  $( This would fail if file processed twice (y redeclared) $)
-  $( But since second include ignored, ax-y and wy are still available globally $)
-  th2 $p |- y $= wy ax-y $.
-$}
+$( Use the declarations provided by the first include $)
+th1 $p |- y $= wy ax-y $.

--- a/goverify/unit-tests/test47_constant_inner_scope_helper.mm
+++ b/goverify/unit-tests/test47_constant_inner_scope_helper.mm
@@ -1,4 +1,0 @@
-$( Helper file for Test 47: Declares $c in non-outermost scope $)
-$( This violates spec §4.2.8: "All $c statements must be in outermost block" $)
-
-$c inner-const $.

--- a/goverify/unit-tests/test47_constant_inner_scope_main.mm
+++ b/goverify/unit-tests/test47_constant_inner_scope_main.mm
@@ -1,11 +1,8 @@
-$( Unit Test 47: $c declaration in inner scope via include $)
-$( Should reject: True - $c must be in outermost block $)
-$( Spec Section 4.2.8: "All $c statements must be placed in the outermost block" $)
+$( Unit Test 47: $c declaration in inner scope $)
+$( Should reject: True - Spec Section 4.1.3 requires $c in outermost block $)
 
 $c wff |- $.
 
 ${
-  $( Include file that contains $c declaration $)
-  $( Since this include is in inner scope, $c is NOT in outermost block $)
-  $[ ./test47_constant_inner_scope_helper.mm $]
+  $c inner-const $.
 $}

--- a/goverify/unit-tests/test49_token_splice_axiom_main.mm
+++ b/goverify/unit-tests/test49_token_splice_axiom_main.mm
@@ -1,7 +1,6 @@
 $( Unit Test 49: Include as token splice in axiom $)
-$( Should reject: False - token splice is valid macro expansion $)
-$( Spec Section 4.4.4: File includes are token splices, can appear anywhere $)
-$( This is MALICIOUS but VALID per spec! $)
+$( Should reject: True - Spec Section 4.1.2 forbids $[ ... $] inside statements $)
+$( Attempting to splice tokens into an assertion must fail $)
 
 $c wff |- $.
 $v x $.

--- a/goverify/unit-tests/test50_token_splice_proof_main.mm
+++ b/goverify/unit-tests/test50_token_splice_proof_main.mm
@@ -1,7 +1,6 @@
 $( Unit Test 50: Include as token splice in proof $)
-$( Should reject: False - token splice is valid macro expansion $)
-$( Spec Section 4.4.4: File includes are token splices $)
-$( This demonstrates proof steps can be in separate file $)
+$( Should reject: True - Spec Section 4.1.2 forbids $[ ... $] inside statements $)
+$( Proof steps cannot be spliced from includes $)
 
 $c wff |- $.
 $v x $.


### PR DESCRIPTION
## Summary
- enforce the parser to reject non-outermost include directives, track already processed files, and keep comment handling spec-compliant
- require `$c` declarations to remain in the outermost scope and simplify include whitespace diagnostics
- refresh include-related unit tests and catalogue entries to match the Metamath specification, removing obsolete fixtures

## Testing
- go build ./...
- python3 unit-tests/run_unit_tests.py ./mmverify --from-files

------
https://chatgpt.com/codex/tasks/task_e_68e58fe1a568832884bb462cc8baa3c0